### PR TITLE
Implement kafka eventbus eventsource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 .idea/
 .DS_Store
+.env
 vendor/
 dist/
 # delve debug binaries

--- a/eventbus/driver.go
+++ b/eventbus/driver.go
@@ -61,7 +61,7 @@ func GetEventSourceDriver(ctx context.Context, eventBusConfig eventbusv1alpha1.B
 			return nil, err
 		}
 	case apicommon.EventBusKafka:
-		dvr = kafkasource.NewKafkaSource([]string{}, logger)
+		dvr = kafkasource.NewKafkaSource([]string{"localhost:9092"}, "events", logger)
 	default:
 		return nil, fmt.Errorf("invalid eventbus type")
 	}
@@ -116,6 +116,8 @@ func GetAuth(ctx context.Context, eventBusConfig eventbusv1alpha1.BusConfig) (*e
 		eventBusAuth = eventBusConfig.NATS.Auth
 	case eventBusConfig.JetStream != nil:
 		eventBusAuth = &eventbusv1alpha1.AuthStrategyBasic
+	case eventBusConfig.Kafka != nil:
+		eventBusAuth = nil
 	default:
 		return nil, fmt.Errorf("invalid event bus")
 	}

--- a/eventbus/driver.go
+++ b/eventbus/driver.go
@@ -3,6 +3,7 @@ package eventbus
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/argoproj/argo-events/common"
 	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
@@ -61,7 +62,7 @@ func GetEventSourceDriver(ctx context.Context, eventBusConfig eventbusv1alpha1.B
 			return nil, err
 		}
 	case apicommon.EventBusKafka:
-		dvr = kafkasource.NewKafkaSource([]string{"localhost:9092"}, "events", logger)
+		dvr = kafkasource.NewKafkaSource(strings.Split(eventBusConfig.Kafka.URL, ","), defaultSubject, logger)
 	default:
 		return nil, fmt.Errorf("invalid eventbus type")
 	}

--- a/eventbus/kafka/base/kafka.go
+++ b/eventbus/kafka/base/kafka.go
@@ -3,21 +3,13 @@ package base
 import "go.uber.org/zap"
 
 type Kafka struct {
-	brokers []string
-	logger  *zap.SugaredLogger
+	Brokers []string
+	Logger  *zap.SugaredLogger
 }
 
 func NewKafka(brokers []string, logger *zap.SugaredLogger) *Kafka {
 	return &Kafka{
-		brokers: brokers,
-		logger:  logger,
+		Brokers: brokers,
+		Logger:  logger,
 	}
-}
-
-func (k *Kafka) MakeConnection() (*KafkaConnection, error) {
-	conn := &KafkaConnection{
-		logger: k.logger,
-	}
-
-	return conn, nil
 }

--- a/eventbus/kafka/base/kafka_conn.go
+++ b/eventbus/kafka/base/kafka_conn.go
@@ -3,13 +3,11 @@ package base
 import "go.uber.org/zap"
 
 type KafkaConnection struct {
-	logger *zap.SugaredLogger
+	Logger *zap.SugaredLogger
 }
 
-func (c *KafkaConnection) Close() error {
-	return nil
-}
-
-func (c *KafkaConnection) IsClosed() bool {
-	return false
+func NewKafkaConnection(logger *zap.SugaredLogger) *KafkaConnection {
+	return &KafkaConnection{
+		Logger: logger,
+	}
 }

--- a/eventbus/kafka/eventsource/source_conn.go
+++ b/eventbus/kafka/eventsource/source_conn.go
@@ -3,14 +3,45 @@ package eventsource
 import (
 	"context"
 
+	"github.com/Shopify/sarama"
 	"github.com/argoproj/argo-events/eventbus/common"
 	"github.com/argoproj/argo-events/eventbus/kafka/base"
+	"go.uber.org/zap"
 )
 
 type KafkaSourceConnection struct {
 	*base.KafkaConnection
+	topic    string
+	client   sarama.Client
+	producer sarama.SyncProducer
 }
 
 func (c *KafkaSourceConnection) Publish(ctx context.Context, msg common.Message) error {
+	key := msg.EventSourceName + ":" + msg.EventName
+
+	partition, offset, err := c.producer.SendMessage(&sarama.ProducerMessage{
+		Topic: c.topic,
+		Key:   sarama.StringEncoder(key),
+		Value: sarama.ByteEncoder(msg.Body),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Infow("Published message to kafka", zap.String("topic", c.topic), zap.Int32("partition", partition), zap.Int64("offset", offset))
+
 	return nil
+}
+
+func (c *KafkaSourceConnection) Close() error {
+	if err := c.producer.Close(); err != nil {
+		return err
+	}
+
+	return c.client.Close()
+}
+
+func (c *KafkaSourceConnection) IsClosed() bool {
+	return c.client.Closed()
 }

--- a/eventbus/kafka/eventsource/source_kafka.go
+++ b/eventbus/kafka/eventsource/source_kafka.go
@@ -1,6 +1,7 @@
 package eventsource
 
 import (
+	"github.com/Shopify/sarama"
 	"github.com/argoproj/argo-events/eventbus/common"
 	"github.com/argoproj/argo-events/eventbus/kafka/base"
 	"go.uber.org/zap"
@@ -8,11 +9,13 @@ import (
 
 type KafkaSource struct {
 	*base.Kafka
+	topic string
 }
 
-func NewKafkaSource(brokers []string, logger *zap.SugaredLogger) *KafkaSource {
+func NewKafkaSource(brokers []string, topic string, logger *zap.SugaredLogger) *KafkaSource {
 	return &KafkaSource{
 		base.NewKafka(brokers, logger),
+		topic,
 	}
 }
 
@@ -21,10 +24,26 @@ func (s *KafkaSource) Initialize() error {
 }
 
 func (s *KafkaSource) Connect(string) (common.EventSourceConnection, error) {
-	conn, err := s.MakeConnection()
+	config := sarama.NewConfig()
+	config.Producer.Return.Errors = true
+	config.Producer.Return.Successes = true
+
+	client, err := sarama.NewClient(s.Brokers, config)
 	if err != nil {
 		return nil, err
 	}
 
-	return &KafkaSourceConnection{conn}, nil
+	producer, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := &KafkaSourceConnection{
+		base.NewKafkaConnection(s.Logger),
+		s.topic,
+		client,
+		producer,
+	}
+
+	return conn, nil
 }


### PR DESCRIPTION
Implement the `Publish` method for the Kafka EventBus. Also implements a temporary `alwaysElector` implementation that we will need to think some more about as the current elector implementation relies on NATs.