### PR TITLE
Optional kubernetes-based leader election

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 .idea/
 .DS_Store
+.env
 vendor/
 dist/
 # delve debug binaries
@@ -12,3 +13,4 @@ debug.test
 *.out
 site/
 /go-diagrams/
+argo-events

--- a/common/common.go
+++ b/common/common.go
@@ -29,6 +29,10 @@ const (
 	EnvVarKubeConfig = "KUBECONFIG"
 	// EnvVarDebugLog is the env var to turn on the debug mode for logging
 	EnvVarDebugLog = "DEBUG_LOG"
+	// ENVVarPodName should be set to the name of the pod
+	EnvVarPodName = "POD_NAME"
+	// ENVVarLeaderElection sets the leader election mode
+	EnvVarLeaderElection = "LEADER_ELECTION"
 	// EnvImagePullPolicy is the env var to set container's ImagePullPolicy
 	EnvImagePullPolicy = "IMAGE_PULL_POLICY"
 )
@@ -119,6 +123,8 @@ const (
 	LabelOwnerName = "owner-name"
 	// AnnotationResourceSpecHash is the annotation of a K8s resource spec hash
 	AnnotationResourceSpecHash = "resource-spec-hash"
+	// AnnotationLeaderElection is the annotation for leader election
+	AnnotationLeaderElection = "events.argoproj.io/leader-election"
 )
 
 // various supported media types

--- a/common/leaderelection/leaderelection.go
+++ b/common/leaderelection/leaderelection.go
@@ -4,17 +4,22 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/nats-io/graft"
 	nats "github.com/nats-io/nats.go"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/argoproj/argo-events/common"
 	"github.com/argoproj/argo-events/common/logging"
 	eventbuscommon "github.com/argoproj/argo-events/eventbus/common"
-	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
 	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 )
 
@@ -27,25 +32,39 @@ type LeaderCallbacks struct {
 	OnStoppedLeading func()
 }
 
-func NewEventBusElector(ctx context.Context, eventBusConfig eventbusv1alpha1.BusConfig, clusterName string, clusterSize int) (Elector, error) {
-	logger := logging.FromContext(ctx)
-
-	var eventBusType apicommon.EventBusType
-	var eventBusAuth *eventbusv1alpha1.AuthStrategy
+func NewElector(ctx context.Context, eventBusConfig eventbusv1alpha1.BusConfig, clusterName string, clusterSize int, namespace string, leasename string, hostname string) (Elector, error) {
 	switch {
+	case ctx.Value("events.argoproj.io/leader-election") == "k8s":
+		return newKubernetesElector(namespace, leasename, hostname)
 	case eventBusConfig.NATS != nil:
-		eventBusType = apicommon.EventBusNATS
-		eventBusAuth = eventBusConfig.NATS.Auth
+		return newEventBusElector(ctx, eventBusConfig.NATS.Auth, clusterName, clusterSize, eventBusConfig.NATS.URL)
 	case eventBusConfig.JetStream != nil:
-		eventBusType = apicommon.EventBusJetStream
-		eventBusAuth = &eventbusv1alpha1.AuthStrategyBasic
+		return newEventBusElector(ctx, &eventbusv1alpha1.AuthStrategyBasic, clusterName, clusterSize, eventBusConfig.JetStream.URL)
 	default:
 		return nil, fmt.Errorf("invalid event bus")
 	}
+}
+
+func newEventBusElector(ctx context.Context, authStrategy *eventbusv1alpha1.AuthStrategy, clusterName string, clusterSize int, url string) (Elector, error) {
+	auth, err := getEventBusAuth(ctx, authStrategy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &natsEventBusElector{
+		clusterName: clusterName,
+		size:        clusterSize,
+		url:         url,
+		auth:        auth,
+	}, nil
+}
+
+func getEventBusAuth(ctx context.Context, authStrategy *eventbusv1alpha1.AuthStrategy) (*eventbuscommon.Auth, error) {
+	logger := logging.FromContext(ctx)
 
 	var auth *eventbuscommon.Auth
-	cred := &eventbuscommon.AuthCredential{}
-	if eventBusAuth == nil || *eventBusAuth == eventbusv1alpha1.AuthStrategyNone {
+
+	if authStrategy == nil || *authStrategy == eventbusv1alpha1.AuthStrategyNone {
 		auth = &eventbuscommon.Auth{
 			Strategy: eventbusv1alpha1.AuthStrategyNone,
 		}
@@ -54,46 +73,30 @@ func NewEventBusElector(ctx context.Context, eventBusConfig eventbusv1alpha1.Bus
 		v.SetConfigName("auth")
 		v.SetConfigType("yaml")
 		v.AddConfigPath(common.EventBusAuthFileMountPath)
-		err := v.ReadInConfig()
-		if err != nil {
+
+		if err := v.ReadInConfig(); err != nil {
 			return nil, fmt.Errorf("failed to load auth.yaml. err: %w", err)
 		}
-		err = v.Unmarshal(cred)
-		if err != nil {
+
+		cred := &eventbuscommon.AuthCredential{}
+		if err := v.Unmarshal(cred); err != nil {
 			logger.Errorw("failed to unmarshal auth.yaml", zap.Error(err))
 			return nil, err
 		}
+
 		v.WatchConfig()
 		v.OnConfigChange(func(e fsnotify.Event) {
 			// Auth file changed, let it restart.
 			logger.Fatal("Eventbus auth config file changed, exiting..")
 		})
+
 		auth = &eventbuscommon.Auth{
-			Strategy:   *eventBusAuth,
+			Strategy:   *authStrategy,
 			Credential: cred,
 		}
 	}
 
-	var elector Elector
-	switch eventBusType {
-	case apicommon.EventBusNATS:
-		elector = &natsEventBusElector{
-			clusterName: clusterName,
-			size:        clusterSize,
-			url:         eventBusConfig.NATS.URL,
-			auth:        auth,
-		}
-	case apicommon.EventBusJetStream:
-		elector = &natsEventBusElector{
-			clusterName: clusterName,
-			size:        clusterSize,
-			url:         eventBusConfig.JetStream.URL,
-			auth:        auth,
-		}
-	default:
-		return nil, fmt.Errorf("invalid eventbus type")
-	}
-	return elector, nil
+	return auth, nil
 }
 
 type natsEventBusElector struct {
@@ -176,6 +179,67 @@ func (e *natsEventBusElector) RunOrDie(ctx context.Context, callbacks LeaderCall
 			handleStateChange(sc)
 		case err := <-errChan:
 			log.Errorw("Error happened", zap.Error(err))
+		}
+	}
+}
+
+type kubernetesElector struct {
+	namespace string
+	leasename string
+	hostname  string
+	client    *kubernetes.Clientset
+}
+
+func newKubernetesElector(namespace string, leasename string, hostname string) (Elector, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubernetesElector{
+		namespace: namespace,
+		leasename: leasename,
+		hostname:  hostname,
+		client:    client,
+	}, nil
+}
+
+func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallbacks) {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      e.leasename,
+			Namespace: e.namespace,
+		},
+		Client: e.client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: e.hostname,
+		},
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			ctx, cancel := context.WithCancel(ctx)
+			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+				Lock:            lock,
+				ReleaseOnCancel: true,
+				LeaseDuration:   15 * time.Second,
+				RenewDeadline:   10 * time.Second,
+				RetryPeriod:     2 * time.Second,
+				Callbacks: leaderelection.LeaderCallbacks{
+					OnStartedLeading: callbacks.OnStartedLeading,
+					OnStoppedLeading: callbacks.OnStoppedLeading,
+				},
+			})
+
+			cancel()
 		}
 	}
 }

--- a/common/leaderelection/leaderelection.go
+++ b/common/leaderelection/leaderelection.go
@@ -239,6 +239,9 @@ func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallba
 				},
 			})
 
+			// When the leader is lost, leaderelection.RunOrDie will
+			// cease blocking and we will cancel the context. This
+			// will halt all eventsource/sensor go routines.
 			cancel()
 		}
 	}

--- a/common/leaderelection/leaderelection_test.go
+++ b/common/leaderelection/leaderelection_test.go
@@ -1,0 +1,51 @@
+package leaderelection
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/argoproj/argo-events/common"
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	configs = []eventbusv1alpha1.BusConfig{
+		{NATS: &eventbusv1alpha1.NATSConfig{}},
+		{JetStream: &eventbusv1alpha1.JetStreamConfig{}},
+	}
+)
+
+func TestLeaderElectionWithInvalidEventBus(t *testing.T) {
+	elector, err := NewElector(context.TODO(), eventbusv1alpha1.BusConfig{}, "", 0, "", "", "")
+
+	assert.Nil(t, elector)
+	assert.EqualError(t, err, "invalid event bus")
+}
+
+func TestLeaderElectionWithEventBusElector(t *testing.T) {
+	eventBusAuthFileMountPath = "test"
+
+	for _, config := range configs {
+		elector, err := NewElector(context.TODO(), config, "", 0, "", "", "")
+		assert.Nil(t, err)
+
+		_, ok := elector.(*natsEventBusElector)
+		assert.True(t, ok)
+	}
+}
+
+func TestLeaderElectionWithKubernetesElector(t *testing.T) {
+	eventBusAuthFileMountPath = "test"
+
+	os.Setenv(common.EnvVarLeaderElection, "k8s")
+
+	for _, config := range configs {
+		elector, err := NewElector(context.TODO(), config, "", 0, "", "", "")
+		assert.Nil(t, err)
+
+		_, ok := elector.(*kubernetesElector)
+		assert.True(t, ok)
+	}
+}

--- a/common/leaderelection/test/auth.yaml
+++ b/common/leaderelection/test/auth.yaml
@@ -1,0 +1,3 @@
+token: "token"
+username: "username"
+password: "password"

--- a/controllers/eventsource/resource.go
+++ b/controllers/eventsource/resource.go
@@ -168,10 +168,8 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	}
 	eventSourceCopy := &v1alpha1.EventSource{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: args.EventSource.Annotations,
-			Labels:      args.EventSource.Labels,
-			Namespace:   args.EventSource.Namespace,
-			Name:        args.EventSource.Name,
+			Namespace: args.EventSource.Namespace,
+			Name:      args.EventSource.Name,
 		},
 		Spec: args.EventSource.Spec,
 	}
@@ -190,8 +188,12 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 			Value: fmt.Sprintf("eventbus-%s", args.EventSource.Namespace),
 		},
 		{
-			Name:      "POD_NAME",
+			Name:      common.EnvVarPodName,
 			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+		},
+		{
+			Name:  common.EnvVarLeaderElection,
+			Value: args.EventSource.Annotations[common.AnnotationLeaderElection],
 		},
 	}
 

--- a/controllers/eventsource/resource.go
+++ b/controllers/eventsource/resource.go
@@ -168,8 +168,10 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	}
 	eventSourceCopy := &v1alpha1.EventSource{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: args.EventSource.Namespace,
-			Name:      args.EventSource.Name,
+			Annotations: args.EventSource.Annotations,
+			Labels:      args.EventSource.Labels,
+			Namespace:   args.EventSource.Namespace,
+			Name:        args.EventSource.Name,
 		},
 		Spec: args.EventSource.Spec,
 	}

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -128,10 +128,8 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	}
 	sensorCopy := &v1alpha1.Sensor{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: args.Sensor.Annotations,
-			Labels:      args.Sensor.Labels,
-			Namespace:   args.Sensor.Namespace,
-			Name:        args.Sensor.Name,
+			Namespace: args.Sensor.Namespace,
+			Name:      args.Sensor.Name,
 		},
 		Spec: args.Sensor.Spec,
 	}
@@ -150,8 +148,12 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 			Value: fmt.Sprintf("eventbus-%s", args.Sensor.Namespace),
 		},
 		{
-			Name:      "POD_NAME",
+			Name:      common.EnvVarPodName,
 			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+		},
+		{
+			Name:  common.EnvVarLeaderElection,
+			Value: args.Sensor.Annotations[common.AnnotationLeaderElection],
 		},
 	}
 

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -128,8 +128,10 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	}
 	sensorCopy := &v1alpha1.Sensor{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: args.Sensor.Namespace,
-			Name:      args.Sensor.Name,
+			Annotations: args.Sensor.Annotations,
+			Labels:      args.Sensor.Labels,
+			Namespace:   args.Sensor.Namespace,
+			Name:        args.Sensor.Name,
 		},
 		Spec: args.Sensor.Spec,
 	}

--- a/docs/eventsources/ha.md
+++ b/docs/eventsources/ha.md
@@ -56,11 +56,24 @@ old one is gone.
 ## Kubernetes Leader Election
 
 By default, Argo Events will use NATS for the HA leader election. Alternatively,
-you can opt-in to a Kubernetes native leader election (that uses a Lease) by
-specifying the following annotation.
+you can opt-in to a Kubernetes native leader election by specifying the following
+annotation.
 ```yaml
 annotations:
   events.argoproj.io/leader-election: k8s
+```
+
+To use Kubernetes leader election the following RBAC rules need to be associated
+with the EventSource ServiceAccount.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-events-leaderelection-role
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs:     ["get", "create", "update"]
 ```
 
 ## More

--- a/docs/eventsources/ha.md
+++ b/docs/eventsources/ha.md
@@ -53,6 +53,16 @@ old one is gone.
 - Redis
 - Resource
 
+## Kubernetes Leader Election
+
+By default, Argo Events will use NATS for the HA leader election. Alternatively,
+you can opt-in to a Kubernetes native leader election (that uses a Lease) by
+specifying the following annotation.
+```yaml
+annotations:
+  events.argoproj.io/leader-election: k8s
+```
+
 ## More
 
 Click [here](../dr_ha_recommendations.md) to learn more information about Argo

--- a/docs/sensors/ha.md
+++ b/docs/sensors/ha.md
@@ -9,5 +9,17 @@ elected to be active if the old one is gone.
 **Please DO NOT manually scale up the replicas, that might cause unexpected
 behaviors!**
 
+## Kubernetes Leader Election
+
+By default, Argo Events will use NATS for the HA leader election. Alternatively,
+you can opt-in to a Kubernetes native leader election (that uses a Lease) by
+specifying the following annotation.
+```yaml
+annotations:
+  events.argoproj.io/leader-election: k8s
+```
+
+## More
+
 Click [here](../dr_ha_recommendations.md) to learn more information about Argo
 Events DR/HA recommendations.

--- a/docs/sensors/ha.md
+++ b/docs/sensors/ha.md
@@ -12,11 +12,24 @@ behaviors!**
 ## Kubernetes Leader Election
 
 By default, Argo Events will use NATS for the HA leader election. Alternatively,
-you can opt-in to a Kubernetes native leader election (that uses a Lease) by
-specifying the following annotation.
+you can opt-in to a Kubernetes native leader election by specifying the following
+annotation.
 ```yaml
 annotations:
   events.argoproj.io/leader-election: k8s
+```
+
+To use Kubernetes leader election the following RBAC rules need to be associated
+with the Sensor ServiceAccount.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-events-leaderelection-role
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs:     ["get", "create", "update"]
 ```
 
 ## More

--- a/eventsources/cmd/start.go
+++ b/eventsources/cmd/start.go
@@ -68,6 +68,7 @@ func Start() {
 	// add annotations to context
 	for key, value := range eventSource.Annotations {
 		if strings.HasPrefix(key, "events.argoproj.io") {
+			// nolint
 			ctx = context.WithValue(ctx, key, value)
 		}
 	}

--- a/eventsources/cmd/start.go
+++ b/eventsources/cmd/start.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -64,14 +62,6 @@ func Start() {
 
 	logger.Infow("starting eventsource server", "version", argoevents.GetVersion())
 	adaptor := eventsources.NewEventSourceAdaptor(eventSource, busConfig, ebSubject, hostname, m)
-
-	// add annotations to context
-	for key, value := range eventSource.Annotations {
-		if strings.HasPrefix(key, "events.argoproj.io") {
-			// nolint
-			ctx = context.WithValue(ctx, key, value)
-		}
-	}
 
 	if err := adaptor.Start(ctx); err != nil {
 		logger.Fatalw("failed to start eventsource server", zap.Error(err))

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -409,7 +409,7 @@ func (e *EventSourceAdaptor) Start(ctx context.Context) error {
 			}
 		},
 		OnStoppedLeading: func() {
-			log.Warnf("leader lost: %s", e.hostname)
+			log.Fatalf("leader lost: %s", e.hostname)
 		},
 	})
 

--- a/sensors/cmd/start.go
+++ b/sensors/cmd/start.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/dynamic"
@@ -82,14 +80,6 @@ func Start() {
 	ctx := logging.WithLogger(signals.SetupSignalHandler(), logger)
 	m := metrics.NewMetrics(sensor.Namespace)
 	go m.Run(ctx, fmt.Sprintf(":%d", common.SensorMetricsPort))
-
-	// add annotations to context
-	for key, value := range sensor.Annotations {
-		if strings.HasPrefix(key, "events.argoproj.io") {
-			// nolint
-			ctx = context.WithValue(ctx, key, value)
-		}
-	}
 
 	logger.Infow("starting sensor server", "version", argoevents.GetVersion())
 	sensorExecutionCtx := sensors.NewSensorContext(kubeClient, dynamicClient, sensor, busConfig, ebSubject, hostname, m)

--- a/sensors/cmd/start.go
+++ b/sensors/cmd/start.go
@@ -86,6 +86,7 @@ func Start() {
 	// add annotations to context
 	for key, value := range sensor.Annotations {
 		if strings.HasPrefix(key, "events.argoproj.io") {
+			// nolint
 			ctx = context.WithValue(ctx, key, value)
 		}
 	}

--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -55,11 +55,11 @@ func subscribeOnce(subLock *uint32, subscribe func()) {
 
 func (sensorCtx *SensorContext) Start(ctx context.Context) error {
 	log := logging.FromContext(ctx)
-	custerName := fmt.Sprintf("%s-sensor-%s", sensorCtx.sensor.Namespace, sensorCtx.sensor.Name)
+	clusterName := fmt.Sprintf("%s-sensor-%s", sensorCtx.sensor.Namespace, sensorCtx.sensor.Name)
 	replicas := int(sensorCtx.sensor.Spec.GetReplicas())
 	leasename := fmt.Sprintf("sensor-%s", sensorCtx.sensor.Name)
 
-	elector, err := leaderelection.NewElector(ctx, *sensorCtx.eventBusConfig, custerName, replicas, sensorCtx.sensor.Namespace, leasename, sensorCtx.hostname)
+	elector, err := leaderelection.NewElector(ctx, *sensorCtx.eventBusConfig, clusterName, replicas, sensorCtx.sensor.Namespace, leasename, sensorCtx.hostname)
 	if err != nil {
 		log.Errorw("failed to get an elector", zap.Error(err))
 		return err

--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -56,11 +56,15 @@ func subscribeOnce(subLock *uint32, subscribe func()) {
 func (sensorCtx *SensorContext) Start(ctx context.Context) error {
 	log := logging.FromContext(ctx)
 	custerName := fmt.Sprintf("%s-sensor-%s", sensorCtx.sensor.Namespace, sensorCtx.sensor.Name)
-	elector, err := leaderelection.NewEventBusElector(ctx, *sensorCtx.eventBusConfig, custerName, int(sensorCtx.sensor.Spec.GetReplicas()))
+	replicas := int(sensorCtx.sensor.Spec.GetReplicas())
+	leasename := fmt.Sprintf("sensor-%s", sensorCtx.sensor.Name)
+
+	elector, err := leaderelection.NewElector(ctx, *sensorCtx.eventBusConfig, custerName, replicas, sensorCtx.sensor.Namespace, leasename, sensorCtx.hostname)
 	if err != nil {
 		log.Errorw("failed to get an elector", zap.Error(err))
 		return err
 	}
+
 	elector.RunOrDie(ctx, leaderelection.LeaderCallbacks{
 		OnStartedLeading: func(ctx context.Context) {
 			if err := sensorCtx.listenEvents(ctx); err != nil {
@@ -68,9 +72,10 @@ func (sensorCtx *SensorContext) Start(ctx context.Context) error {
 			}
 		},
 		OnStoppedLeading: func() {
-			log.Fatalf("leader lost: %s", sensorCtx.hostname)
+			log.Warnf("leader lost: %s", sensorCtx.hostname)
 		},
 	})
+
 	return nil
 }
 

--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -72,7 +72,7 @@ func (sensorCtx *SensorContext) Start(ctx context.Context) error {
 			}
 		},
 		OnStoppedLeading: func() {
-			log.Warnf("leader lost: %s", sensorCtx.hostname)
+			log.Fatalf("leader lost: %s", sensorCtx.hostname)
 		},
 	})
 

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -69,24 +69,31 @@ func (s *FunctionalSuite) TestCreateCalendarEventSource() {
 }
 
 func (s *FunctionalSuite) TestCreateCalendarEventSourceWithHA() {
-	t1 := s.Given().EventSource("@testdata/es-calendar-ha.yaml").
-		When().
-		CreateEventSource().
-		WaitForEventSourceReady().
-		Wait(3 * time.Second).
-		Then().
-		ExpectEventSourcePodLogContains(LogPublishEventSuccessful)
+	for _, test := range []struct {
+		es, s string
+	}{
+		{"@testdata/es-calendar-ha.yaml", "@testdata/sensor-log-ha.yaml"},
+		{"@testdata/es-calendar-ha-k8s.yaml", "@testdata/sensor-log-ha-k8s.yaml"},
+	} {
+		t1 := s.Given().EventSource(test.es).
+			When().
+			CreateEventSource().
+			WaitForEventSourceReady().
+			Wait(3 * time.Second).
+			Then().
+			ExpectEventSourcePodLogContains(LogPublishEventSuccessful)
 
-	defer t1.When().DeleteEventSource()
+		defer t1.When().DeleteEventSource()
 
-	t2 := s.Given().Sensor("@testdata/sensor-log-ha.yaml").
-		When().
-		CreateSensor().
-		WaitForSensorReady().
-		Wait(3 * time.Second).
-		Then().
-		ExpectSensorPodLogContains(LogTriggerActionSuccessful("log-trigger"))
-	defer t2.When().DeleteSensor()
+		t2 := s.Given().Sensor(test.s).
+			When().
+			CreateSensor().
+			WaitForSensorReady().
+			Wait(3 * time.Second).
+			Then().
+			ExpectSensorPodLogContains(LogTriggerActionSuccessful("log-trigger"))
+		defer t2.When().DeleteSensor()
+	}
 }
 
 func (s *FunctionalSuite) TestMetricsWithCalendar() {

--- a/test/e2e/testdata/es-calendar-ha-k8s.yaml
+++ b/test/e2e/testdata/es-calendar-ha-k8s.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  annotations:
+    events.argoproj.io/leader-election: k8s
+  name: e2e-calendar-ha-k8s
+spec:
+  replicas: 2
+  template:
+    serviceAccountName: argo-events-sa
+  calendar:
+    example:
+      interval: 2s

--- a/test/e2e/testdata/sensor-log-ha-k8s.yaml
+++ b/test/e2e/testdata/sensor-log-ha-k8s.yaml
@@ -6,6 +6,8 @@ metadata:
   name: e2e-log-ha-k8s
 spec:
   replicas: 2
+  template:
+    serviceAccountName: argo-events-sa
   dependencies:
     - name: test-dep
       eventSourceName: e2e-calendar-ha-k8s

--- a/test/e2e/testdata/sensor-log-ha-k8s.yaml
+++ b/test/e2e/testdata/sensor-log-ha-k8s.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  annotations:
+    events.argoproj.io/leader-election: k8s
+  name: e2e-log-ha-k8s
+spec:
+  replicas: 2
+  dependencies:
+    - name: test-dep
+      eventSourceName: e2e-calendar-ha-k8s
+      eventName: example
+  triggers:
+    - template:
+        name: log-trigger
+        log: {}


### PR DESCRIPTION
The following annotation can be set on both `EventSource` and `Sensor` to opt in to kubernetes-based leader election.
```yaml
annotations:
  events.argoproj.io/leader-election: k8s
```

This decouples the leader election from the event bus type, which will especially come in handy when we implement a Kafka EventBus.