### PR TITLE
Reset kafka consumer on cleanup

### DIFF
--- a/eventbus/kafka/sensor/kafka_handler.go
+++ b/eventbus/kafka/sensor/kafka_handler.go
@@ -26,6 +26,10 @@ type KafkaHandler struct {
 	// offset and an optional function that will in a transaction
 	Handlers map[string]func(*sarama.ConsumerMessage) ([]*sarama.ProducerMessage, int64, func())
 
+	// cleanup function
+	// used to clear state when consumer group is rebalanced
+	Reset func() error
+
 	// maintains a mapping of keys (which correspond to triggers)
 	// to offsets, used to ensure triggers aren't invoked twice
 	checkpoints Checkpoints
@@ -68,6 +72,8 @@ func (c *Checkpoint) Metadata() string {
 }
 
 func (h *KafkaHandler) Setup(session sarama.ConsumerGroupSession) error {
+	h.Logger.Infow("Kafka setup", zap.Any("claims", session.Claims()))
+
 	// instantiates checkpoints for all topic/partitions managed by
 	// this claim
 	h.checkpoints = Checkpoints{}
@@ -115,7 +121,8 @@ func (h *KafkaHandler) Setup(session sarama.ConsumerGroupSession) error {
 }
 
 func (h *KafkaHandler) Cleanup(session sarama.ConsumerGroupSession) error {
-	return nil
+	h.Logger.Infow("Kafka cleanup", zap.Any("claims", session.Claims()))
+	return h.Reset()
 }
 
 func (h *KafkaHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
@@ -158,12 +165,13 @@ func (h *KafkaHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim s
 			var fns []func()
 
 			for _, msg := range msgs {
+				key := string(msg.Key)
+
 				h.Logger.Infow("Received message",
 					zap.String("topic", msg.Topic),
+					zap.String("key", key),
 					zap.Int32("partition", msg.Partition),
 					zap.Int64("offset", msg.Offset))
-
-				key := string(msg.Key)
 
 				if checkpoint.Init {
 					// mark offset in order to reconsume from this

--- a/eventbus/kafka/sensor/kafka_sensor.go
+++ b/eventbus/kafka/sensor/kafka_sensor.go
@@ -141,6 +141,7 @@ func (s *KafkaSensor) Initialize() error {
 		Producer:      producer,
 		OffsetManager: offsetManager,
 		TriggerTopic:  s.topics.trigger,
+		Reset:         s.Reset,
 		Handlers: map[string]func(*sarama.ConsumerMessage) ([]*sarama.ProducerMessage, int64, func()){
 			s.topics.event:   s.Event,
 			s.topics.trigger: s.Trigger,
@@ -366,4 +367,12 @@ func (s *KafkaSensor) Action(msg *sarama.ConsumerMessage) ([]*sarama.ProducerMes
 	}
 
 	return nil, msg.Offset + 1, f
+}
+
+func (s *KafkaSensor) Reset() error {
+	for _, trigger := range s.triggers {
+		trigger.Reset()
+	}
+
+	return nil
 }

--- a/eventbus/kafka/sensor/trigger_handler.go
+++ b/eventbus/kafka/sensor/trigger_handler.go
@@ -14,6 +14,7 @@ type KafkaTriggerHandler interface {
 	common.TriggerConnection
 	Name() string
 	Ready() bool
+	Reset()
 	OneAndDone() bool
 	DependsOn(*cloudevents.Event) (string, bool)
 	Transform(string, *cloudevents.Event) (*cloudevents.Event, error)
@@ -90,7 +91,7 @@ func (c *KafkaTriggerConnection) Update(event *cloudevents.Event, partition int3
 	// all events and reset the trigger
 	var events []*cloudevents.Event
 	if satisfied == true {
-		defer c.reset()
+		defer c.Reset()
 		for _, event := range c.events {
 			events = append(events, event.Event)
 		}
@@ -144,7 +145,7 @@ func (c *KafkaTriggerConnection) satisfied() (interface{}, error) {
 	return c.depExpression.Eval(parameters)
 }
 
-func (c *KafkaTriggerConnection) reset() {
+func (c *KafkaTriggerConnection) Reset() {
 	c.events = nil
 }
 


### PR DESCRIPTION
When a partition is unassigned from one consumer and assigned to a different consumer, we need to clear the trigger state. If we don't clear this state false trigger invocations can occur if a partition is reassigned back to a consumer that it was previously assigned to because stale messages will still be in memory.
